### PR TITLE
Add automatic screenshot capture on test failure with HTML report integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs/
 pages/__pycache__/
 tests/__pycache__/
 utils/__pycache__/
+screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pages/__pycache__/
 tests/__pycache__/
 utils/__pycache__/
 screenshots/
+reports/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -v -ra --html=../reports/report.html --self-contained-html


### PR DESCRIPTION
This PR introduces a pytest hook that captures a screenshot when a test fails and automatically attaches it to the pytest HTML report.